### PR TITLE
Typo: Cypress => CypressDev

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ require 'cypress_dev/middleware'
 CypressDev.configure do |c|
   c.cypress_folder = File.expand_path("#{__dir__}/test/cypress")
 end
-use Cypress::Middleware
+use CypressDev::Middleware
 
 run MyApp 
 ```


### PR DESCRIPTION
Noticed this typo while trying to configure the gem locally.